### PR TITLE
Replace startup crash vectors with graceful error handling

### DIFF
--- a/InvoiceGeneration/Services/PersistenceController.swift
+++ b/InvoiceGeneration/Services/PersistenceController.swift
@@ -6,15 +6,18 @@ import OSLog
 enum PersistenceController {
     static let logger = Logger(subsystem: "InvoiceGeneration", category: "Persistence")
 
-    static let shared: ModelContainer = makeContainer(inMemory: false)
-    static let preview: ModelContainer = makeContainer(inMemory: true)
+    // swiftlint:disable:next force_try
+    static let preview: ModelContainer = try! makeContainer(inMemory: true)
 
-    private static func makeContainer(inMemory: Bool) -> ModelContainer {
+    // MARK: - Public
+
+    /// Creates the shared ModelContainer. Throws if even the in-memory fallback cannot be created.
+    static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
         let shouldUseInMemory = inMemory || ProcessInfo.processInfo.arguments.contains("UITEST_USE_IN_MEMORY_STORE")
 
         if shouldUseInMemory {
             let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-            return try! ModelContainer(
+            return try ModelContainer(
                 for: Invoice.self,
                 InvoiceItem.self,
                 CompanyProfile.self,
@@ -65,10 +68,12 @@ enum PersistenceController {
                 )
             } catch {
                 logger.critical("Disk-backed SwiftData container failed after reset (\(error.localizedDescription)); falling back to in-memory store.")
-                return makeContainer(inMemory: true)
+                return try makeContainer(inMemory: true)
             }
         }
     }
+
+    // MARK: - Private
 
     private static func diskConfiguration() throws -> ModelConfiguration {
         let url = try storeURL()

--- a/InvoiceGeneration/Services/SubscriptionService.swift
+++ b/InvoiceGeneration/Services/SubscriptionService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import StoreKit
 import Combine
 
@@ -56,11 +57,17 @@ final class SubscriptionService: ObservableObject {
         }
     }
 
+    private static let logger = Logger(subsystem: "InvoiceGeneration", category: "StoreKit")
+
     static let shared: SubscriptionService = {
         do {
             return try SubscriptionService(storeConfiguration: StoreConfiguration.load())
         } catch {
-            fatalError("Invalid StoreKit configuration: \(error.localizedDescription)")
+            logger.critical("StoreKit configuration invalid: \(error.localizedDescription). Running in free-tier mode.")
+            // StoreConfiguration.testing has hardcoded valid non-empty product IDs, so this init cannot throw.
+            // startTasks: false prevents StoreKit calls with invalid identifiers.
+            // swiftlint:disable:next force_try
+            return try! SubscriptionService(storeConfiguration: .testing, startTasks: false)
         }
     }()
 

--- a/InvoiceGeneration/Views/InvoiceGeneratorApp.swift
+++ b/InvoiceGeneration/Views/InvoiceGeneratorApp.swift
@@ -1,24 +1,38 @@
-import SwiftUI
+import OSLog
 import SwiftData
+import SwiftUI
 
 /// Main app entry point with SwiftData configuration
 @main
 struct InvoiceGeneratorApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var subscriptionService = SubscriptionService.shared
-    private let modelContainer = PersistenceController.shared
+
+    private static let containerResult: Result<ModelContainer, Error> = {
+        do {
+            return .success(try PersistenceController.makeContainer())
+        } catch {
+            PersistenceController.logger.critical("ModelContainer failed to initialize: \(error.localizedDescription)")
+            return .failure(error)
+        }
+    }()
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(subscriptionService)
-        }
-        .modelContainer(modelContainer)
-        .onChange(of: scenePhase) { _, newPhase in
-            guard newPhase == .active else { return }
-            Task {
-                await subscriptionService.refreshEntitlements()
-                await subscriptionService.refreshICloudAvailability()
+            switch Self.containerResult {
+            case .success(let container):
+                ContentView()
+                    .environmentObject(subscriptionService)
+                    .modelContainer(container)
+                    .onChange(of: scenePhase) { _, newPhase in
+                        guard newPhase == .active else { return }
+                        Task {
+                            await subscriptionService.refreshEntitlements()
+                            await subscriptionService.refreshICloudAvailability()
+                        }
+                    }
+            case .failure(let error):
+                PersistenceErrorView(error: error)
             }
         }
     }

--- a/InvoiceGeneration/Views/PersistenceErrorView.swift
+++ b/InvoiceGeneration/Views/PersistenceErrorView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Shown when the SwiftData ModelContainer cannot be created at startup.
+struct PersistenceErrorView: View {
+    let error: Error
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 56))
+                .foregroundStyle(.orange)
+
+            VStack(spacing: 8) {
+                Text(String(localized: "Unable to Open Data", comment: "Persistence error title"))
+                    .font(.title2.bold())
+
+                Text(String(localized: "Your data could not be loaded. This may be caused by low disk space or a storage error. Please restart the app. If the problem persists, free up disk space and try again.", comment: "Persistence error body"))
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(32)
+    }
+}


### PR DESCRIPTION
## Summary

- **`PersistenceController`**: Removed `shared` static let; exposed `makeContainer() throws` so the app entry point owns container creation. The in-memory `try!` at line 17 is now a regular `try` — if even the fallback container can't be created, the error propagates gracefully instead of crashing.
- **`SubscriptionService`**: Replaced `fatalError` (triggered when `StoreKitProMonthlyProductID`/`StoreKitProYearlyProductID` are missing from `Info.plist`) with `Logger.critical(...)` + free-tier fallback using `StoreConfiguration.testing` and `startTasks: false`. No crash; purchases are silently disabled in degraded mode.
- **`InvoiceGeneratorApp`**: Replaced `private let modelContainer = PersistenceController.shared` with a `static let containerResult: Result<ModelContainer, Error>`. The `body` branches on success (normal app) vs failure (new `PersistenceErrorView`).
- **`PersistenceErrorView`** (new): Minimal localized error screen shown when `ModelContainer` cannot be initialized at startup.

## Test plan

- [ ] Build succeeds: `xcodebuild -scheme InvoiceGeneration -destination 'platform=iOS Simulator,name=iPhone 16' build`
- [ ] Tests pass: `xcodebuild -scheme InvoiceGeneration -destination 'platform=iOS Simulator,name=iPhone 16' test`
- [ ] Simulate StoreKit failure: temporarily remove `StoreKitProMonthlyProductID` from `Info.plist`, confirm app launches in free-tier mode (no crash) and OSLog shows a `.critical` entry in the `StoreKit` category
- [ ] Confirm all Xcode previews still render (they use `PersistenceController.preview` which is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)