### PR TITLE
Fix decimal values being truncated in invoice items

### DIFF
--- a/InvoiceGeneration/Views/AddClientView.swift
+++ b/InvoiceGeneration/Views/AddClientView.swift
@@ -174,8 +174,8 @@ struct AddClientView: View {
     private func persist() {
         let accentHex = accentColor.hexString ?? Client.defaultAccentHex
         let dueDaysValue = Int(defaultDueDays) ?? InvoiceFlowPreferences.defaultDueDays
-        let ivaValue = Decimal(string: defaultIVAPercentage)
-        let irpfValue = Decimal(string: defaultIRPFPercentage)
+        let ivaValue = Decimal(string: defaultIVAPercentage, locale: Locale.current)
+        let irpfValue = Decimal(string: defaultIRPFPercentage, locale: Locale.current)
 
         switch mode {
         case .create:

--- a/InvoiceGeneration/Views/AddInvoiceView.swift
+++ b/InvoiceGeneration/Views/AddInvoiceView.swift
@@ -544,11 +544,11 @@ struct AddInvoiceView: View {
     }
 
     private var ivaPercentageValue: Decimal {
-        Decimal(string: ivaPercentage) ?? 0
+        Decimal(string: ivaPercentage, locale: Locale.current) ?? 0
     }
 
     private var irpfPercentageValue: Decimal {
-        Decimal(string: irpfPercentage) ?? 0
+        Decimal(string: irpfPercentage, locale: Locale.current) ?? 0
     }
 
     private var ivaAmount: Decimal {

--- a/InvoiceGeneration/Views/AddItemView.swift
+++ b/InvoiceGeneration/Views/AddItemView.swift
@@ -28,7 +28,7 @@ struct AddItemView: View {
 #endif
                 }
                 
-                if let price = Decimal(string: unitPrice), price > 0 {
+                if let price = Decimal(string: unitPrice, locale: Locale.current), price > 0 {
                     Section {
                         LabeledContent("Total", value: (price * Decimal(quantity)).formattedAsCurrency)
                     }
@@ -56,11 +56,11 @@ struct AddItemView: View {
     }
     
     private var isValid: Bool {
-        !itemDescription.isEmpty && quantity > 0 && Decimal(string: unitPrice) != nil
+        !itemDescription.isEmpty && quantity > 0 && Decimal(string: unitPrice, locale: Locale.current) != nil
     }
-    
+
     private func addItem() {
-        guard let price = Decimal(string: unitPrice) else { return }
+        guard let price = Decimal(string: unitPrice, locale: Locale.current) else { return }
         
         viewModel.addItem(
             to: invoice,
@@ -284,11 +284,11 @@ struct EditInvoiceView: View {
     }
 
     private var ivaPercentageValue: Decimal {
-        Decimal(string: ivaPercentage) ?? 0
+        Decimal(string: ivaPercentage, locale: Locale.current) ?? 0
     }
 
     private var irpfPercentageValue: Decimal {
-        Decimal(string: irpfPercentage) ?? 0
+        Decimal(string: irpfPercentage, locale: Locale.current) ?? 0
     }
 
     private func handleAddClientTap() {

--- a/InvoiceGeneration/Views/InvoiceDetailView.swift
+++ b/InvoiceGeneration/Views/InvoiceDetailView.swift
@@ -1016,7 +1016,13 @@ struct InvoiceItemEditorView: View {
         self.item = item
         _descriptionText = State(initialValue: item.itemDescription)
         _quantity = State(initialValue: item.quantity)
-        _unitPrice = State(initialValue: NSDecimalNumber(decimal: item.unitPrice).stringValue)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale.current
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        formatter.groupingSeparator = ""
+        _unitPrice = State(initialValue: formatter.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
     }
 
     var body: some View {
@@ -1031,7 +1037,7 @@ struct InvoiceItemEditorView: View {
                         .keyboardType(.decimalPad)
     #endif
                 }
-                if let price = Decimal(string: unitPrice), price > 0 {
+                if let price = Decimal(string: unitPrice, locale: Locale.current), price > 0 {
                     Section {
                         LabeledContent("Total", value: (price * Decimal(quantity)).formattedAsCurrency)
                     }
@@ -1054,11 +1060,11 @@ struct InvoiceItemEditorView: View {
     }
 
     private var isValid: Bool {
-        !descriptionText.isEmpty && Decimal(string: unitPrice) != nil
+        !descriptionText.isEmpty && Decimal(string: unitPrice, locale: Locale.current) != nil
     }
 
     private func saveChanges() {
-        guard let price = Decimal(string: unitPrice) else { return }
+        guard let price = Decimal(string: unitPrice, locale: Locale.current) else { return }
         viewModel.updateItem(
             item,
             from: invoice,

--- a/InvoiceGeneration/Views/InvoiceEditorComponents.swift
+++ b/InvoiceGeneration/Views/InvoiceEditorComponents.swift
@@ -202,11 +202,11 @@ struct InvoiceEditorSections: View {
     }
 
     private var ivaPercentageValue: Decimal {
-        Decimal(string: ivaPercentage) ?? 0
+        Decimal(string: ivaPercentage, locale: Locale.current) ?? 0
     }
 
     private var irpfPercentageValue: Decimal {
-        Decimal(string: irpfPercentage) ?? 0
+        Decimal(string: irpfPercentage, locale: Locale.current) ?? 0
     }
 
     private var ivaAmount: Decimal {
@@ -260,7 +260,13 @@ struct InvoiceDraftItemEditor: View {
         case .edit(let item):
             _descriptionText = State(initialValue: item.description)
             _quantity = State(initialValue: item.quantity)
-            _unitPrice = State(initialValue: NSDecimalNumber(decimal: item.unitPrice).stringValue)
+            let priceFormatter = NumberFormatter()
+            priceFormatter.numberStyle = .decimal
+            priceFormatter.locale = Locale.current
+            priceFormatter.maximumFractionDigits = 2
+            priceFormatter.minimumFractionDigits = 0
+            priceFormatter.groupingSeparator = ""
+            _unitPrice = State(initialValue: priceFormatter.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
             _vatRate = State(initialValue: item.vatRate)
         }
     }
@@ -286,7 +292,7 @@ struct InvoiceDraftItemEditor: View {
                     }
                 }
 
-                if let price = Decimal(string: unitPrice), price > 0 {
+                if let price = Decimal(string: unitPrice, locale: Locale.current), price > 0 {
                     Section {
                         LabeledContent("Total", value: (price * Decimal(quantity)).formattedAsCurrency)
                     }
@@ -320,11 +326,11 @@ struct InvoiceDraftItemEditor: View {
     }
 
     private var isValid: Bool {
-        !descriptionText.isEmpty && Decimal(string: unitPrice) != nil
+        !descriptionText.isEmpty && Decimal(string: unitPrice, locale: Locale.current) != nil
     }
 
     private func persist() {
-        guard let price = Decimal(string: unitPrice) else { return }
+        guard let price = Decimal(string: unitPrice, locale: Locale.current) else { return }
 
         let identifier: UUID
         switch mode {


### PR DESCRIPTION
Decimal(string:) without a locale parameter doesn't parse comma decimal
separators used in Spanish and other European locales (e.g. "2461,05").
This caused the decimal portion to be silently dropped when saving items.

Fix: pass Locale.current to all Decimal(string:locale:) calls across
item price fields, IVA/IRPF percentage fields, and client defaults.
Also fix the initial value formatting when editing existing items to use
locale-aware NumberFormatter instead of NSDecimalNumber.stringValue
(which always uses dot notation).

https://claude.ai/code/session_011Jfehs4GYeR7wk1GCRuTR2