### PR TITLE
Fix optional collection handling in invoice and template tests

### DIFF
--- a/InvoiceGenerationTests/InvoiceGenerationTests.swift
+++ b/InvoiceGenerationTests/InvoiceGenerationTests.swift
@@ -45,6 +45,7 @@ struct InvoiceGenerationTests {
     @Test func example() async throws {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
+    @MainActor
     @Test func freePlanCapsClientsAtTwo() async throws {
         let service = makeSubscriptionService()
 
@@ -267,7 +268,7 @@ struct InvoiceGenerationTests {
         )
         let templateItem = InvoiceTemplateItem(description: "Retainer", quantity: 1, unitPrice: 1200, sortOrder: 0)
         templateItem.template = template
-        template.items.append(templateItem)
+        template.items = (template.items ?? []) + [templateItem]
 
         context.insert(issuer)
         context.insert(client)
@@ -283,7 +284,7 @@ struct InvoiceGenerationTests {
         #expect(created != nil)
         #expect(created?.clientName == "Cliente")
         #expect(created?.invoiceNumber == "ACM-0001")
-        #expect(created?.items.count == 1)
+        #expect(created?.items?.count == 1)
         #expect(created?.ivaPercentage == 21)
         #expect(created?.irpfPercentage == 15)
         #expect(created?.notes == "Retainer mensual")
@@ -310,7 +311,7 @@ struct InvoiceGenerationTests {
         original.captureIssuerSnapshot(from: issuer)
         let item = InvoiceItem(description: "Retainer", quantity: 1, unitPrice: 1000)
         item.invoice = original
-        original.items.append(item)
+        original.items = (original.items ?? []) + [item]
         original.calculateTotal()
 
         context.insert(issuer)
@@ -326,7 +327,7 @@ struct InvoiceGenerationTests {
         #expect(copy?.invoiceNumber == "ACM-0002")
         #expect(copy?.issueDate == original.issueDate.addingMonths(1))
         #expect(copy?.dueDate == original.issueDate.addingMonths(1).addingDays(15))
-        #expect(copy?.items.count == 1)
+        #expect(copy?.items?.count == 1)
         #expect(copy?.totalAmount == original.totalAmount)
     }
 
@@ -348,7 +349,7 @@ struct InvoiceGenerationTests {
         invoice.captureIssuerSnapshot(from: issuer)
         let item = InvoiceItem(description: "Retainer", quantity: 1, unitPrice: 1000)
         item.invoice = invoice
-        invoice.items.append(item)
+        invoice.items = (invoice.items ?? []) + [item]
         invoice.calculateTotal()
 
         context.insert(issuer)
@@ -362,7 +363,7 @@ struct InvoiceGenerationTests {
 
         #expect(template != nil)
         #expect(client.preferredTemplateID == template?.id)
-        #expect(template?.items.count == 1)
+        #expect(template?.items?.count == 1)
     }
 
     @MainActor
@@ -437,7 +438,7 @@ struct InvoiceGenerationTests {
         invoice.captureIssuerSnapshot(from: issuer)
         let item = InvoiceItem(description: "Servicio mensual", quantity: 1, unitPrice: 1000)
         item.invoice = invoice
-        invoice.items.append(item)
+        invoice.items = (invoice.items ?? []) + [item]
         invoice.calculateTotal()
 
         let document = PDFGeneratorService.generateInvoicePDF(invoice: invoice)


### PR DESCRIPTION
## Summary
Updates test code to properly handle optional collection types in SwiftData models. Changes reflect that `items` collections on `Invoice` and `InvoiceTemplate` are now optional, requiring safe unwrapping and nil-coalescing when appending or accessing.

## Key Changes
- Added `@MainActor` annotation to `freePlanCapsClientsAtTwo()` test for thread safety
- Replaced direct `.append()` calls with nil-coalescing assignment pattern: `items = (items ?? []) + [newItem]` across four test methods
  - `testInvoiceGenerationFromTemplate()`
  - `testInvoiceDuplication()`
  - `testTemplateCreationFromInvoice()`
  - `testPDFGeneration()`
- Updated assertions to safely unwrap optional `items` collections using optional chaining: `items?.count` instead of `items.count`

## Implementation Details
The changes maintain the same functional behavior while adapting to optional collection semantics. The nil-coalescing pattern `(items ?? []) + [newItem]` safely handles both initialized and uninitialized collections, avoiding force unwrapping and improving robustness of test setup code.

https://claude.ai/code/session_012McejxboP5ScXTrz6iNwMm