### PR TITLE
Validate VeriFACTU hash format before persisting

### DIFF
--- a/InvoiceGeneration/Services/VerifactuHashService.swift
+++ b/InvoiceGeneration/Services/VerifactuHashService.swift
@@ -9,7 +9,39 @@ import SwiftData
 /// `SHA-256(NIF + NumFactura + FechaExpedicion + TipoFactura + CuotaTotal + ImporteTotal + HuellaAnterior + FechaHoraRegistro)`
 enum VerifactuHashService {
 
+    // MARK: - Errors
+
+    /// Errors raised when a VeriFACTU hash fails AEAT format validation.
+    enum HashValidationError: Error, Equatable, LocalizedError {
+        /// The hash did not have the required SHA-256 length.
+        case invalidLength(actual: Int)
+        /// The hash contained characters outside the expected hexadecimal range/casing.
+        case invalidCharacters
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidLength(let actual):
+                return String(
+                    format: String(
+                        localized: "VeriFACTU hash must be %d characters but was %d.",
+                        comment: "Verifactu hash invalid length error"
+                    ),
+                    VerifactuHashService.expectedHashLength,
+                    actual
+                )
+            case .invalidCharacters:
+                return String(
+                    localized: "VeriFACTU hash contains characters that are not valid lowercase hexadecimal.",
+                    comment: "Verifactu hash invalid characters error"
+                )
+            }
+        }
+    }
+
     // MARK: - Constants
+
+    /// Required character length of a SHA-256 hash represented as hexadecimal (32 bytes × 2 chars).
+    static let expectedHashLength = 64
 
     /// Sentinel value used as `previousHash` for the first record in an issuer's chain.
     static let chainSentinel = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -54,6 +86,35 @@ enum VerifactuHashService {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
+    // MARK: - Hash Validation
+
+    /// Returns `true` when `hash` conforms to the canonical VeriFACTU SHA-256 format used by
+    /// this codebase: a 64-character lowercase hexadecimal string.
+    ///
+    /// AEAT requires the registry footprint (huella) to be a SHA-256 digest. This app emits the
+    /// digest as lowercase hex (see `generateHash`) and recomputes/compares it in the same casing
+    /// during chain verification, so validation enforces that exact convention.
+    static func isValidHash(_ hash: String) -> Bool {
+        (try? validateHash(hash)) != nil
+    }
+
+    /// Validates that `hash` conforms to the canonical VeriFACTU SHA-256 format (64-character
+    /// lowercase hexadecimal) before it is persisted to a `VerifactuRecord`.
+    ///
+    /// - Parameter hash: The hash string to validate.
+    /// - Throws: `HashValidationError` describing why the hash is out of spec.
+    static func validateHash(_ hash: String) throws {
+        guard hash.count == expectedHashLength else {
+            throw HashValidationError.invalidLength(actual: hash.count)
+        }
+        let isValidHex = hash.allSatisfy { character in
+            character.isNumber || ("a"..."f").contains(character)
+        }
+        guard isValidHex else {
+            throw HashValidationError.invalidCharacters
+        }
+    }
+
     // MARK: - Record Creation
 
     /// Creates a VeriFACTU record for an invoice and appends it to the issuer's hash chain.
@@ -63,12 +124,13 @@ enum VerifactuHashService {
     ///   - issuer: The issuer whose chain will be extended
     ///   - context: SwiftData model context for persistence
     /// - Returns: The created `VerifactuRecord`, already inserted into `context`
+    /// - Throws: `HashValidationError` if the generated hash is not a valid SHA-256 hex string.
     @discardableResult
     static func createRecord(
         for invoice: Invoice,
         issuer: Issuer,
         context: ModelContext
-    ) -> VerifactuRecord {
+    ) throws -> VerifactuRecord {
         let previousHash = issuer.lastVerifactuHash.isEmpty
             ? chainSentinel
             : issuer.lastVerifactuHash
@@ -85,6 +147,9 @@ enum VerifactuHashService {
             previousHash: previousHash,
             recordTimestamp: recordTimestamp
         )
+
+        // Reject out-of-spec hashes before they reach `recordHash` and the AEAT payload.
+        try validateHash(hash)
 
         let qrUrl = VerifactuQRService.verificationUrl(
             issuerTaxId: issuer.taxId,
@@ -124,12 +189,13 @@ enum VerifactuHashService {
     }
 
     /// Creates a cancellation (anulación) record for an invoice.
+    /// - Throws: `HashValidationError` if the generated hash is not a valid SHA-256 hex string.
     @discardableResult
     static func createCancellationRecord(
         for invoice: Invoice,
         issuer: Issuer,
         context: ModelContext
-    ) -> VerifactuRecord {
+    ) throws -> VerifactuRecord {
         let previousHash = issuer.lastVerifactuHash.isEmpty
             ? chainSentinel
             : issuer.lastVerifactuHash
@@ -146,6 +212,9 @@ enum VerifactuHashService {
             previousHash: previousHash,
             recordTimestamp: recordTimestamp
         )
+
+        // Reject out-of-spec hashes before they reach `recordHash` and the AEAT payload.
+        try validateHash(hash)
 
         let record = VerifactuRecord(
             issuerTaxId: issuer.taxId,

--- a/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
+++ b/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
@@ -140,9 +140,17 @@ final class InvoiceViewModel {
         }
         invoice.calculateTotal()
 
-        // Generate VeriFACTU record if issuer has compliance enabled
+        // Generate VeriFACTU record if issuer has compliance enabled.
+        // A malformed hash must never be persisted, so abort creation if validation fails.
         if issuer.verifactuEnabled {
-            VerifactuHashService.createRecord(for: invoice, issuer: issuer, context: modelContext)
+            do {
+                try VerifactuHashService.createRecord(for: invoice, issuer: issuer, context: modelContext)
+            } catch {
+                PersistenceController.logger.error("VeriFACTU record creation failed: \(error.localizedDescription)")
+                errorMessage = error.localizedDescription
+                modelContext.rollback()
+                return nil
+            }
         }
 
         guard saveContext() else { return nil }

--- a/InvoiceGenerationTests/InvoiceGenerationTests.swift
+++ b/InvoiceGenerationTests/InvoiceGenerationTests.swift
@@ -605,7 +605,149 @@ struct InvoiceGenerationTests {
             Issuer.self,
             InvoiceTemplate.self,
             InvoiceTemplateItem.self,
+            TaxBreakdown.self,
+            VerifactuRecord.self,
             configurations: configuration
         )
+    }
+
+    @MainActor
+    private func makeVerifactuInvoice(
+        number: String,
+        issuer: Issuer,
+        context: ModelContext
+    ) -> Invoice {
+        let invoice = Invoice(
+            invoiceNumber: number,
+            clientName: "Cliente",
+            clientIdentificationNumber: "B87654321",
+            issuer: issuer,
+            ivaPercentage: 21
+        )
+        invoice.captureIssuerSnapshot(from: issuer)
+        let item = InvoiceItem(description: "Servicio", quantity: 1, unitPrice: 1000)
+        item.invoice = invoice
+        invoice.items = [item]
+        invoice.calculateTotal()
+        context.insert(invoice)
+        context.insert(item)
+        return invoice
+    }
+
+    // MARK: - VeriFACTU Coverage
+
+    @MainActor
+    @Test func verifactuChainLinksRecordsAndIncrementsSequence() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let issuer = Issuer(name: "Acme SL", code: "ACM", taxId: "B12345678", verifactuEnabled: true)
+        context.insert(issuer)
+
+        let first = makeVerifactuInvoice(number: "ACM-0001", issuer: issuer, context: context)
+        let firstRecord = try VerifactuHashService.createRecord(for: first, issuer: issuer, context: context)
+
+        #expect(firstRecord.sequenceNumber == 1)
+        #expect(firstRecord.previousHash == VerifactuHashService.chainSentinel)
+        #expect(issuer.verifactuSequence == 2)
+        #expect(issuer.lastVerifactuHash == firstRecord.recordHash)
+
+        let second = makeVerifactuInvoice(number: "ACM-0002", issuer: issuer, context: context)
+        let secondRecord = try VerifactuHashService.createRecord(for: second, issuer: issuer, context: context)
+
+        #expect(secondRecord.sequenceNumber == 2)
+        #expect(secondRecord.previousHash == firstRecord.recordHash)
+        #expect(issuer.verifactuSequence == 3)
+
+        let result = VerifactuHashService.verifyChain(for: issuer, context: context)
+        #expect(result.isValid)
+        #expect(result.brokenAtSequence == nil)
+    }
+
+    @MainActor
+    @Test func verifactuChainDetectsTampering() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let issuer = Issuer(name: "Acme SL", code: "ACM", taxId: "B12345678", verifactuEnabled: true)
+        context.insert(issuer)
+
+        let inv1 = makeVerifactuInvoice(number: "ACM-0001", issuer: issuer, context: context)
+        let r1 = try VerifactuHashService.createRecord(for: inv1, issuer: issuer, context: context)
+        let inv2 = makeVerifactuInvoice(number: "ACM-0002", issuer: issuer, context: context)
+        _ = try VerifactuHashService.createRecord(for: inv2, issuer: issuer, context: context)
+
+        // Tamper with the first record's amount so its recomputed hash no longer matches.
+        r1.totalAmount += 100
+
+        let result = VerifactuHashService.verifyChain(for: issuer, context: context)
+        #expect(!result.isValid)
+        #expect(result.brokenAtSequence == 1)
+    }
+
+    @MainActor
+    @Test func verifactuSubmissionStatusTransitions() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let issuer = Issuer(name: "Acme SL", code: "ACM", taxId: "B12345678", verifactuEnabled: true)
+        context.insert(issuer)
+
+        let invoice = makeVerifactuInvoice(number: "ACM-0001", issuer: issuer, context: context)
+        let record = try VerifactuHashService.createRecord(for: invoice, issuer: issuer, context: context)
+
+        #expect(record.submissionStatus == .pending)
+        #expect(record.submissionDate == nil)
+
+        VerifactuSubmissionService.markAsSubmitted(record)
+        #expect(record.submissionStatus == .submitted)
+        #expect(record.submissionDate != nil)
+
+        VerifactuSubmissionService.markAsAccepted(record, response: "CSV-123456")
+        #expect(record.submissionStatus == .accepted)
+        #expect(record.submissionResponse == "CSV-123456")
+
+        let stats = VerifactuSubmissionService.statistics(for: issuer)
+        #expect(stats.total == 1)
+        #expect(stats.accepted == 1)
+        #expect(stats.pending == 0)
+        #expect(stats.hasUnsubmitted == false)
+    }
+
+    @MainActor
+    @Test func verifactuAltaXMLContainsRequiredAEATElements() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let issuer = Issuer(name: "Acme SL", code: "ACM", taxId: "B12345678", verifactuEnabled: true)
+        context.insert(issuer)
+
+        let invoice = makeVerifactuInvoice(number: "ACM-0001", issuer: issuer, context: context)
+        let record = try VerifactuHashService.createRecord(for: invoice, issuer: issuer, context: context)
+
+        let xml = VerifactuXMLService.generateAltaXML(record: record, invoice: invoice, issuer: issuer)
+
+        #expect(xml.contains("SuministroLRFacturasEmitidas"))
+        #expect(xml.contains("<sif:NumSerieFactura>ACM-0001</sif:NumSerieFactura>"))
+        #expect(xml.contains("<sif:NIF>B12345678</sif:NIF>"))
+        #expect(xml.contains("<sif:TipoFactura>F1</sif:TipoFactura>"))
+        #expect(xml.contains("<sif:Huella>\(record.recordHash)</sif:Huella>"))
+        #expect(xml.contains("<sif:HuellaAnterior>\(record.previousHash)</sif:HuellaAnterior>"))
+        #expect(xml.contains("<sif:NumRegistro>\(record.sequenceNumber)</sif:NumRegistro>"))
+        #expect(xml.contains("<sif:ImporteTotal>1210.00</sif:ImporteTotal>"))
+    }
+
+    @MainActor
+    @Test func verifactuAnulacionXMLUsesBajaStructure() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let issuer = Issuer(name: "Acme SL", code: "ACM", taxId: "B12345678", verifactuEnabled: true)
+        context.insert(issuer)
+
+        let invoice = makeVerifactuInvoice(number: "ACM-0001", issuer: issuer, context: context)
+        let record = try VerifactuHashService.createCancellationRecord(for: invoice, issuer: issuer, context: context)
+
+        #expect(record.isCancellation)
+
+        let xml = VerifactuXMLService.generateAnulacionXML(record: record, issuer: issuer)
+        #expect(xml.contains("BajaLRFacturasEmitidas"))
+        #expect(xml.contains("RegistroLRBajaExpedidas"))
+        #expect(xml.contains("<sif:NumSerieFactura>ACM-0001</sif:NumSerieFactura>"))
     }
 }

--- a/InvoiceGenerationTests/InvoiceGenerationTests.swift
+++ b/InvoiceGenerationTests/InvoiceGenerationTests.swift
@@ -162,6 +162,49 @@ struct InvoiceGenerationTests {
         #expect(configuration.subscriptionGroupID == "group.invoicegeneration.pro")
     }
 
+    @Test func verifactuHashValidatorAcceptsCanonicalDigest() throws {
+        let hash = VerifactuHashService.generateHash(
+            issuerTaxId: "B12345678",
+            invoiceNumber: "FAM-0001",
+            issueDate: Date(timeIntervalSince1970: 0),
+            invoiceType: .f1,
+            totalTax: Decimal(21),
+            totalAmount: Decimal(121),
+            previousHash: VerifactuHashService.chainSentinel,
+            recordTimestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(hash.count == VerifactuHashService.expectedHashLength)
+        #expect(VerifactuHashService.isValidHash(hash))
+        try VerifactuHashService.validateHash(hash)
+    }
+
+    @Test func verifactuHashValidatorAcceptsSentinel() async throws {
+        #expect(VerifactuHashService.isValidHash(VerifactuHashService.chainSentinel))
+    }
+
+    @Test func verifactuHashValidatorRejectsWrongLength() async throws {
+        let short = String(repeating: "a", count: 63)
+        #expect(!VerifactuHashService.isValidHash(short))
+        #expect(throws: VerifactuHashService.HashValidationError.invalidLength(actual: 63)) {
+            try VerifactuHashService.validateHash(short)
+        }
+    }
+
+    @Test func verifactuHashValidatorRejectsUppercaseAndNonHex() async throws {
+        let uppercase = String(repeating: "A", count: 64)
+        let nonHex = String(repeating: "g", count: 64)
+
+        #expect(!VerifactuHashService.isValidHash(uppercase))
+        #expect(!VerifactuHashService.isValidHash(nonHex))
+        #expect(throws: VerifactuHashService.HashValidationError.invalidCharacters) {
+            try VerifactuHashService.validateHash(uppercase)
+        }
+        #expect(throws: VerifactuHashService.HashValidationError.invalidCharacters) {
+            try VerifactuHashService.validateHash(nonHex)
+        }
+    }
+
     @MainActor
     @Test func issuerNumberingIncrementsSequence() async throws {
         let issuer = Issuer(name: "Family", code: "FAM")


### PR DESCRIPTION
## Summary
Hashes written to `VerifactuRecord.recordHash` were never validated against the AEAT SHA-256 format (issue #4). An out-of-spec hash could be persisted and then silently rejected by AEAT or cause an audit failure.

- Added `VerifactuHashService.validateHash` / `isValidHash` enforcing the canonical format this codebase emits: a **64-character lowercase hexadecimal** string (matches `generateHash` and chain verification).
- Gated `createRecord` and `createCancellationRecord` on validation — both now `throw HashValidationError` *before* the hash reaches `recordHash` and the AEAT payload.
- `InvoiceViewModel` now rolls back the context and surfaces an error if validation fails, instead of persisting a bad record.
- Added unit tests: canonical digest accepted, sentinel accepted, wrong length rejected, uppercase/non-hex rejected.

## Note on base branch
Stacked on `fix/tests-compile` (PR #43) because the new tests require the test target to compile. Retarget to `main` once #43 merges.

## Test plan
- [x] `build-for-testing` → TEST BUILD SUCCEEDED
- [x] Unit suite green (30 tests, incl. 4 new validator tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)