### PR TITLE
Remove dead notification bell buttons

### DIFF
--- a/InvoiceGeneration/Views/iOS/iOSDashboardView.swift
+++ b/InvoiceGeneration/Views/iOS/iOSDashboardView.swift
@@ -46,14 +46,6 @@ struct iOSDashboardView: View {
                         .font(.title3)
                         .foregroundStyle(.secondary)
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        // Notifications placeholder
-                    } label: {
-                        Image(systemName: "bell")
-                            .foregroundStyle(.secondary)
-                    }
-                }
             }
         }
         .onAppear {

--- a/InvoiceGeneration/Views/iOS/iOSInvoiceListView.swift
+++ b/InvoiceGeneration/Views/iOS/iOSInvoiceListView.swift
@@ -36,14 +36,6 @@ struct iOSInvoiceListView: View {
                         .font(.title3)
                         .foregroundStyle(.secondary)
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        // Notifications placeholder
-                    } label: {
-                        Image(systemName: "bell")
-                            .foregroundStyle(.secondary)
-                    }
-                }
             }
             .navigationDestination(item: $selectedInvoice) { invoice in
                 if let viewModel {


### PR DESCRIPTION
## Summary
The bell toolbar buttons in `iOSInvoiceListView` and `iOSDashboardView` had empty action bodies (`// Notifications placeholder`) — they looked tappable but did nothing (issues #5/#12). The notifications feature doesn't exist, so the buttons are removed rather than left as dead controls.

A sweep of the rest of `Views/` found no other no-op buttons (the only other `placeholder` match is `EmptyStateView`, a legitimate reusable empty-state component).

## Test plan
- [x] `xcodebuild ... build` → BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)