### PR TITLE
Localize user-facing errors and cache formatters

### DIFF
--- a/InvoiceGeneration/Utils/Extensions.swift
+++ b/InvoiceGeneration/Utils/Extensions.swift
@@ -3,42 +3,27 @@ import Foundation
 /// Extension for decimal formatting
 extension Decimal {
     var formattedAsCurrency: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.locale = Locale.current
-        return formatter.string(from: self as NSDecimalNumber) ?? "$0.00"
+        Formatters.currency.string(from: self as NSDecimalNumber) ?? "$0.00"
     }
 
     var formattedAsPercent: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .percent
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 0
-        formatter.locale = Locale.current
         let percentValue = self / Decimal(100)
-        return formatter.string(from: percentValue as NSDecimalNumber) ?? "\(self)%"
+        return Formatters.percent.string(from: percentValue as NSDecimalNumber) ?? "\(self)%"
     }
 }
 
 /// Extension for date formatting
 extension Date {
     var shortFormat: String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
-        return formatter.string(from: self)
+        Formatters.shortDate.string(from: self)
     }
-    
+
     var mediumFormat: String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        return formatter.string(from: self)
+        Formatters.mediumDate.string(from: self)
     }
 
     var monthYearFormat: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.dateFormat = "LLLL yyyy"
-        return formatter.string(from: self)
+        Formatters.monthYear.string(from: self)
     }
 
     var startOfMonth: Date {

--- a/InvoiceGeneration/Utils/Formatters.swift
+++ b/InvoiceGeneration/Utils/Formatters.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Centralized, cached formatter instances.
+///
+/// `NumberFormatter` and `DateFormatter` are expensive to allocate, so creating
+/// them inline (e.g. per cell render) hurts scroll performance. These shared
+/// instances preserve the exact formatting/locale behavior used previously while
+/// avoiding repeated allocation.
+enum Formatters {
+
+    // MARK: - Number Formatters
+
+    /// Currency formatter following the current locale.
+    static let currency: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale.current
+        return formatter
+    }()
+
+    /// Percent formatter (0–2 fraction digits) following the current locale.
+    static let percent: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .percent
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        formatter.locale = Locale.current
+        return formatter
+    }()
+
+    /// Decimal formatter for editable prices: no grouping separator, 0–2 fraction digits.
+    static let editablePrice: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale.current
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        formatter.groupingSeparator = ""
+        return formatter
+    }()
+
+    // MARK: - Date Formatters
+
+    /// Short date style (e.g. `5/22/26`).
+    static let shortDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        return formatter
+    }()
+
+    /// Medium date style (e.g. `May 22, 2026`).
+    static let mediumDate: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    /// Medium date with short time (e.g. `May 22, 2026 at 9:41 AM`).
+    static let mediumDateShortTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Full month + year (e.g. `May 2026`).
+    static let monthYear: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "LLLL yyyy"
+        return formatter
+    }()
+
+    /// Abbreviated month + year (e.g. `May 2026`).
+    static let abbreviatedMonthYear: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "MMM yyyy"
+        return formatter
+    }()
+}

--- a/InvoiceGeneration/Utils/UserFacingError.swift
+++ b/InvoiceGeneration/Utils/UserFacingError.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Maps internal errors to localized, user-friendly messages.
+///
+/// Surfacing `error.localizedDescription` directly leaks technical, often
+/// English-only text to users. These helpers translate known operations into
+/// clear localized messages, falling back to a generic message for anything
+/// unexpected.
+enum UserFacingError {
+
+    /// The data operation that failed, used to pick an appropriate message.
+    enum Operation {
+        case load
+        case save
+        case sync
+        case delete
+        case imageImport
+        case purchase
+    }
+
+    /// Returns a localized, user-friendly message for the given operation.
+    ///
+    /// If the underlying error already provides a localized description via
+    /// `LocalizedError` (e.g. a domain error with curated copy), that message is
+    /// preferred. Otherwise a per-operation localized message is returned.
+    static func message(for operation: Operation, error: Error? = nil) -> String {
+        if let localized = (error as? LocalizedError)?.errorDescription, !localized.isEmpty {
+            return localized
+        }
+
+        switch operation {
+        case .load:
+            return String(localized: "We couldn't load your data. Please try again.")
+        case .save:
+            return String(localized: "We couldn't save your changes. Please try again.")
+        case .sync:
+            return String(localized: "We couldn't sync with iCloud. Your changes are saved on this device.")
+        case .delete:
+            return String(localized: "We couldn't delete this item. Please try again.")
+        case .imageImport:
+            return String(localized: "We couldn't read the selected image. Please try a clearer photo.")
+        case .purchase:
+            return String(localized: "We couldn't complete your purchase. Please try again.")
+        }
+    }
+}

--- a/InvoiceGeneration/ViewModels/ClientViewModel.swift
+++ b/InvoiceGeneration/ViewModels/ClientViewModel.swift
@@ -35,7 +35,7 @@ final class ClientViewModel {
             )
             clients = try modelContext.fetch(descriptor)
         } catch {
-            errorMessage = "Failed to fetch clients: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
 
         isLoading = false
@@ -79,7 +79,7 @@ final class ClientViewModel {
             fetchClients()
         } catch {
             PersistenceController.logger.error("Failed to save client: \(error.localizedDescription)")
-            errorMessage = "Failed to save client: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
             return nil
         }
 
@@ -178,7 +178,7 @@ final class ClientViewModel {
             return true
         } catch {
             PersistenceController.logger.error("SwiftData save failed: \(error.localizedDescription)")
-            errorMessage = "Failed to save: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
             return false
         }
     }

--- a/InvoiceGeneration/ViewModels/CompanyProfileViewModel.swift
+++ b/InvoiceGeneration/ViewModels/CompanyProfileViewModel.swift
@@ -27,7 +27,7 @@ final class CompanyProfileViewModel {
             let profiles = try modelContext.fetch(descriptor)
             profile = profiles.first
         } catch {
-            errorMessage = "Failed to fetch profile: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
         
         isLoading = false
@@ -88,7 +88,7 @@ final class CompanyProfileViewModel {
             try modelContext.save()
         } catch {
             PersistenceController.logger.error("Failed to save profile: \(error.localizedDescription)")
-            errorMessage = "Failed to save profile: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
         }
     }
 }

--- a/InvoiceGeneration/ViewModels/DashboardViewModel.swift
+++ b/InvoiceGeneration/ViewModels/DashboardViewModel.swift
@@ -30,7 +30,7 @@ final class DashboardViewModel {
                 invoices = fetchedInvoices
             }
         } catch {
-            errorMessage = "Failed to load invoices: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
     }
 

--- a/InvoiceGeneration/ViewModels/HomeViewModel.swift
+++ b/InvoiceGeneration/ViewModels/HomeViewModel.swift
@@ -79,7 +79,7 @@ final class HomeViewModel {
                 yearOverYearGrowth = paidThisYear > 0 ? 100 : 0
             }
         } catch {
-            errorMessage = "No se pudo cargar Inicio: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
     }
 

--- a/InvoiceGeneration/ViewModels/InvoiceTemplateViewModel.swift
+++ b/InvoiceGeneration/ViewModels/InvoiceTemplateViewModel.swift
@@ -26,7 +26,7 @@ final class InvoiceTemplateViewModel {
             )
             templates = try modelContext.fetch(descriptor)
         } catch {
-            errorMessage = "No se pudieron cargar las plantillas: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
 
         isLoading = false
@@ -155,7 +155,7 @@ final class InvoiceTemplateViewModel {
             try modelContext.save()
             return true
         } catch {
-            errorMessage = "No se pudo guardar la plantilla: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
             PersistenceController.logger.error("Failed to save template: \(error.localizedDescription)")
             return false
         }

--- a/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
+++ b/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
@@ -62,7 +62,7 @@ final class InvoiceViewModel {
 
             invoices = fetchedInvoices
         } catch {
-            errorMessage = "Failed to fetch invoices: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
 
         isLoading = false
@@ -446,7 +446,7 @@ final class InvoiceViewModel {
             return true
         } catch {
             PersistenceController.logger.error("SwiftData save failed: \(error.localizedDescription)")
-            errorMessage = "Failed to save: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
             return false
         }
     }
@@ -497,7 +497,7 @@ final class InvoiceViewModel {
                 $0.code.caseInsensitiveCompare(invoice.issuerCode) == .orderedSame
             }
         } catch {
-            errorMessage = "No se pudo localizar el emisor: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
             return nil
         }
     }

--- a/InvoiceGeneration/ViewModels/IssuerViewModel.swift
+++ b/InvoiceGeneration/ViewModels/IssuerViewModel.swift
@@ -25,7 +25,7 @@ final class IssuerViewModel {
             descriptor.predicate = #Predicate<Issuer> { !$0.isDeleted }
             issuers = try modelContext.fetch(descriptor)
         } catch {
-            errorMessage = "Failed to fetch issuers: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .load, error: error)
         }
 
         isLoading = false
@@ -175,7 +175,7 @@ final class IssuerViewModel {
             try modelContext.save()
             return true
         } catch {
-            errorMessage = "Failed to save issuer: \(error.localizedDescription)"
+            errorMessage = UserFacingError.message(for: .save, error: error)
             PersistenceController.logger.error("Failed to save issuer: \(error.localizedDescription)")
             return false
         }

--- a/InvoiceGeneration/Views/AddInvoiceView.swift
+++ b/InvoiceGeneration/Views/AddInvoiceView.swift
@@ -861,7 +861,7 @@ struct AddInvoiceView: View {
 
             await importImageData(imageData)
         } catch {
-            importErrorMessage = "La seleccion de imagen fallo: \(error.localizedDescription)"
+            importErrorMessage = UserFacingError.message(for: .imageImport, error: error)
         }
     }
 #endif
@@ -877,7 +877,7 @@ struct AddInvoiceView: View {
             let importedDraft = try await service.extractDraft(from: imageData)
             applyImportedDraft(importedDraft)
         } catch {
-            importErrorMessage = error.localizedDescription
+            importErrorMessage = UserFacingError.message(for: .imageImport, error: error)
         }
 
         isImportingDraft = false

--- a/InvoiceGeneration/Views/DashboardView.swift
+++ b/InvoiceGeneration/Views/DashboardView.swift
@@ -179,10 +179,7 @@ struct DashboardView: View {
     }
 
     private func monthLabel(for date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.dateFormat = "MMM yyyy"
-        return formatter.string(from: date)
+        Formatters.abbreviatedMonthYear.string(from: date)
     }
 
     private func loadViewModelIfNeeded() {

--- a/InvoiceGeneration/Views/InvoiceDetailView.swift
+++ b/InvoiceGeneration/Views/InvoiceDetailView.swift
@@ -734,10 +734,7 @@ struct InvoiceDetailView: View {
     }
 
     private func formattedDate(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter.string(from: date)
+        Formatters.mediumDateShortTime.string(from: date)
     }
 
     private var statusColor: Color {
@@ -1016,13 +1013,7 @@ struct InvoiceItemEditorView: View {
         self.item = item
         _descriptionText = State(initialValue: item.itemDescription)
         _quantity = State(initialValue: item.quantity)
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.locale = Locale.current
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 0
-        formatter.groupingSeparator = ""
-        _unitPrice = State(initialValue: formatter.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
+        _unitPrice = State(initialValue: Formatters.editablePrice.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
     }
 
     var body: some View {

--- a/InvoiceGeneration/Views/InvoiceEditorComponents.swift
+++ b/InvoiceGeneration/Views/InvoiceEditorComponents.swift
@@ -260,13 +260,7 @@ struct InvoiceDraftItemEditor: View {
         case .edit(let item):
             _descriptionText = State(initialValue: item.description)
             _quantity = State(initialValue: item.quantity)
-            let priceFormatter = NumberFormatter()
-            priceFormatter.numberStyle = .decimal
-            priceFormatter.locale = Locale.current
-            priceFormatter.maximumFractionDigits = 2
-            priceFormatter.minimumFractionDigits = 0
-            priceFormatter.groupingSeparator = ""
-            _unitPrice = State(initialValue: priceFormatter.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
+            _unitPrice = State(initialValue: Formatters.editablePrice.string(from: NSDecimalNumber(decimal: item.unitPrice)) ?? "0")
             _vatRate = State(initialValue: item.vatRate)
         }
     }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -4,6 +4,108 @@
     "#%lld" : {
 
     },
+    "We couldn't complete your purchase. Please try again." : {
+      "comment" : "Generic user-facing error when a purchase fails.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't complete your purchase. Please try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo completar la compra. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "We couldn't delete this item. Please try again." : {
+      "comment" : "Generic user-facing error when a delete fails.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't delete this item. Please try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo eliminar este elemento. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "We couldn't load your data. Please try again." : {
+      "comment" : "Generic user-facing error when a data load fails.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't load your data. Please try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron cargar los datos. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "We couldn't read the selected image. Please try a clearer photo." : {
+      "comment" : "User-facing error when an imported invoice image cannot be read.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't read the selected image. Please try a clearer photo."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo leer la imagen seleccionada. Prueba con una foto más nítida."
+          }
+        }
+      }
+    },
+    "We couldn't save your changes. Please try again." : {
+      "comment" : "Generic user-facing error when a save fails.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't save your changes. Please try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron guardar los cambios. Inténtalo de nuevo."
+          }
+        }
+      }
+    },
+    "We couldn't sync with iCloud. Your changes are saved on this device." : {
+      "comment" : "User-facing error when iCloud sync fails.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn't sync with iCloud. Your changes are saved on this device."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo sincronizar con iCloud. Tus cambios están guardados en este dispositivo."
+          }
+        }
+      }
+    },
     "%@ (%@)" : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
## Summary
Two issues (#10/#11):

### Localized errors (#10)
User-facing error messages were raw `error.localizedDescription` strings with inconsistent English/Spanish prefixes. Added `UserFacingError`, which maps a data operation (`load` / `save` / `sync` / `delete` / `imageImport` / `purchase`) to a localized message (EN + ES added to `Localizable.xcstrings`). It prefers an **app-defined** `LocalizedError`'s own curated copy when present; system/SwiftData `NSError`s fall through to the friendly generic message.
- Wired all 16 user-facing error sites across the ViewModels and `AddInvoiceView`.
- Developer `logger.error(...)` calls intentionally keep the technical `localizedDescription`.

### Cached formatters (#11)
`NumberFormatter` / `DateFormatter` were allocated on every access — including per-cell in lists (`Decimal.formattedAsCurrency`, `Date.shortFormat`/`mediumFormat`/`monthYearFormat`) and per-render helpers in Dashboard/Detail/editor views. Added a cached `Formatters` enum and routed the hot paths and the four inline view formatters through it. Formatting/locale output is unchanged.

## Test plan
- [x] `xcodebuild ... build` → BUILD SUCCEEDED
- [x] String catalog validates as JSON
- [ ] Spot-check a forced error (e.g. failed save) shows the localized message in ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)