### PR TITLE
refactor: push issuer filter into SwiftData store predicate (#6)

### DIFF
--- a/InvoiceGeneration/ViewModels/DashboardViewModel.swift
+++ b/InvoiceGeneration/ViewModels/DashboardViewModel.swift
@@ -18,17 +18,16 @@ final class DashboardViewModel {
 
     /// Refresh invoices for analytics calculations
     func fetchInvoices() {
+        let currentIssuerID = issuerFilterID
         do {
+            let predicate = #Predicate<Invoice> { invoice in
+                currentIssuerID == nil || invoice.issuer?.id == currentIssuerID
+            }
             let descriptor = FetchDescriptor<Invoice>(
+                predicate: predicate,
                 sortBy: [SortDescriptor(\.issueDate, order: .reverse)]
             )
-            let fetchedInvoices = try modelContext.fetch(descriptor)
-
-            if let issuerFilterID {
-                invoices = fetchedInvoices.filter { $0.issuer?.id == issuerFilterID }
-            } else {
-                invoices = fetchedInvoices
-            }
+            invoices = try modelContext.fetch(descriptor)
         } catch {
             errorMessage = "Failed to load invoices: \(error.localizedDescription)"
         }

--- a/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
+++ b/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
@@ -33,21 +33,26 @@ final class InvoiceViewModel {
         let currentQuery = searchQuery
 
         do {
+            // The issuer relationship filter runs in the store via #Predicate so we
+            // don't load other issuers' invoices. Combining multiple optional-relationship
+            // clauses (e.g. client AND issuer) overwhelms the #Predicate type-checker in
+            // Swift 5.9/5.10, so only the issuer clause lives in the store predicate;
+            // client, status, and free-text search filter in-memory over the narrowed set.
+            let predicate = #Predicate<Invoice> { invoice in
+                currentIssuerID == nil || invoice.issuer?.id == currentIssuerID
+            }
             let descriptor = FetchDescriptor<Invoice>(
+                predicate: predicate,
                 sortBy: [SortDescriptor(\.issueDate, order: .reverse)]
             )
             var fetchedInvoices = try modelContext.fetch(descriptor)
-
-            if let currentStatus {
-                fetchedInvoices = fetchedInvoices.filter { $0.status == currentStatus }
-            }
 
             if let currentClientID {
                 fetchedInvoices = fetchedInvoices.filter { $0.client?.id == currentClientID }
             }
 
-            if let currentIssuerID {
-                fetchedInvoices = fetchedInvoices.filter { $0.issuer?.id == currentIssuerID }
+            if let currentStatus {
+                fetchedInvoices = fetchedInvoices.filter { $0.status == currentStatus }
             }
 
             if !currentQuery.isEmpty {


### PR DESCRIPTION
## Summary

- **`DashboardViewModel`**: converted the post-fetch in-memory issuer filter to a `#Predicate`-backed `FetchDescriptor`, so SwiftData narrows at the store layer.
- **`InvoiceViewModel`**: likewise pushes the issuer filter into a store `#Predicate`; the client filter is applied in-memory immediately after the store fetch, followed by status and free-text search.

## Why only one clause in `InvoiceViewModel`?

Combining multiple optional-relationship clauses (e.g. `client?.id AND issuer?.id`) overwhelms the Swift 5.9/5.10 `#Predicate` type-checker — the compiler emits _"unable to type-check this expression in reasonable time"_. This is a known limitation of the `#Predicate` macro with compound optional-chain comparisons. The restriction is documented in a comment inside `fetchInvoices()`.

The issuer clause was chosen for the store predicate because it maps 1-to-many and is the most common filter in practice (a user typically views invoices for one issuer at a time). The client filter is applied in-memory over the already-narrowed set and remains functionally correct.

## Test plan

- [ ] Build succeeds (`xcodebuild … build` → `BUILD SUCCEEDED`) ✅
- [ ] Filtering by issuer in Invoice List shows only that issuer's invoices
- [ ] Filtering by client in Invoice List shows only that client's invoices
- [ ] Status filter and search query still work as before
- [ ] Dashboard analytics only include the selected issuer's invoices

🤖 Generated with [Claude Code](https://claude.com/claude-code)