### PR TITLE
refactor: centralise CloudKit write-back in SyncCoordinator (#8/#9)

### DIFF
--- a/InvoiceGeneration/Services/SyncCoordinator.swift
+++ b/InvoiceGeneration/Services/SyncCoordinator.swift
@@ -1,0 +1,111 @@
+import Foundation
+import OSLog
+
+// MARK: - SyncCoordinator
+
+/// Centralises all CloudKit write-back calls so ViewModels don't repeat the
+/// "check syncEnabled → spawn Task → call service → log on error" idiom
+/// individually. Injected into ViewModels at init time (default: `.shared`),
+/// which lets tests supply a no-op stub without touching the singletons.
+final class SyncCoordinator {
+
+    // MARK: - Shared instance
+
+    static let shared = SyncCoordinator()
+
+    // MARK: - Dependencies
+
+    private let subscriptionService: SubscriptionService
+    private let cloudKitService: CloudKitService
+    private let logger = Logger(subsystem: "InvoiceGeneration", category: "SyncCoordinator")
+
+    // MARK: - Init
+
+    /// Designated initialiser — uses real singletons by default; tests can
+    /// override either dependency via this initialiser.
+    init(
+        subscriptionService: SubscriptionService = .shared,
+        cloudKitService: CloudKitService = .shared
+    ) {
+        self.subscriptionService = subscriptionService
+        self.cloudKitService = cloudKitService
+    }
+
+    // MARK: - Invoice sync
+
+    /// Sync a set of invoices to CloudKit if the current subscription allows it.
+    func syncInvoices(_ invoices: [Invoice]) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.syncInvoices(invoices)
+            } catch {
+                logger.error("CloudKit invoice sync failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Remove a single invoice from CloudKit if sync is enabled.
+    func deleteInvoice(with id: UUID) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.deleteInvoice(with: id)
+            } catch {
+                logger.error("CloudKit invoice delete failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Client sync
+
+    /// Sync a set of clients to CloudKit if the current subscription allows it.
+    func syncClients(_ clients: [Client]) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.syncClients(clients)
+            } catch {
+                logger.error("CloudKit client sync failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Remove a single client from CloudKit if sync is enabled.
+    func deleteClient(with id: UUID) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.deleteClient(with: id)
+            } catch {
+                logger.error("CloudKit client delete failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Issuer sync
+
+    /// Sync a set of issuers to CloudKit if the current subscription allows it.
+    func syncIssuers(_ issuers: [Issuer]) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.syncIssuers(issuers)
+            } catch {
+                logger.error("CloudKit issuer sync failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Remove a single issuer from CloudKit if sync is enabled.
+    func deleteIssuer(with id: UUID) {
+        guard subscriptionService.syncEnabled else { return }
+        Task {
+            do {
+                try await cloudKitService.deleteIssuer(with: id)
+            } catch {
+                logger.error("CloudKit issuer delete failed: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/InvoiceGeneration/ViewModels/ClientViewModel.swift
+++ b/InvoiceGeneration/ViewModels/ClientViewModel.swift
@@ -7,14 +7,16 @@ import SwiftData
 @Observable
 final class ClientViewModel {
     private var modelContext: ModelContext
+    private let sync: SyncCoordinator
 
     var clients: [Client] = []
     var isLoading = false
     var errorMessage: String?
     var searchQuery = ""
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, syncCoordinator: SyncCoordinator = .shared) {
         self.modelContext = modelContext
+        self.sync = syncCoordinator
         fetchClients()
     }
 
@@ -83,13 +85,7 @@ final class ClientViewModel {
             return nil
         }
 
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.syncClients([client]) }
-                catch { PersistenceController.logger.error("CloudKit client sync failed: \(error.localizedDescription)") }
-            }
-        }
-
+        sync.syncClients([client])
         return client
     }
 
@@ -128,12 +124,7 @@ final class ClientViewModel {
         let saved = saveContext()
         if saved {
             fetchClients()
-            if SubscriptionService.shared.syncEnabled {
-                Task {
-                    do { try await CloudKitService.shared.syncClients([client]) }
-                    catch { PersistenceController.logger.error("CloudKit client sync failed: \(error.localizedDescription)") }
-                }
-            }
+            sync.syncClients([client])
         }
         return saved
     }
@@ -149,12 +140,7 @@ final class ClientViewModel {
         _ = saveContext()
         fetchClients()
 
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.deleteClient(with: clientID) }
-                catch { PersistenceController.logger.error("CloudKit client delete failed: \(error.localizedDescription)") }
-            }
-        }
+        sync.deleteClient(with: clientID)
     }
 
     func searchClients(query: String) {

--- a/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
+++ b/InvoiceGeneration/ViewModels/InvoiceViewModel.swift
@@ -7,6 +7,7 @@ import Observation
 @Observable
 final class InvoiceViewModel {
     private var modelContext: ModelContext
+    private let sync: SyncCoordinator
 
     var invoices: [Invoice] = []
     var selectedInvoice: Invoice?
@@ -17,8 +18,9 @@ final class InvoiceViewModel {
     var issuerFilterID: UUID?
     var searchQuery = ""
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, syncCoordinator: SyncCoordinator = .shared) {
         self.modelContext = modelContext
+        self.sync = syncCoordinator
         fetchInvoices()
     }
 
@@ -147,14 +149,7 @@ final class InvoiceViewModel {
 
         guard saveContext() else { return nil }
         fetchInvoices()
-
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.syncInvoices([invoice]) }
-                catch { PersistenceController.logger.error("CloudKit invoice sync failed: \(error.localizedDescription)") }
-            }
-        }
-
+        sync.syncInvoices([invoice])
         return invoice
     }
 
@@ -243,13 +238,7 @@ final class InvoiceViewModel {
         invoice.calculateTotal()
         _ = saveContext()
         fetchInvoices()
-
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.syncInvoices([invoice]) }
-                catch { PersistenceController.logger.error("CloudKit invoice sync failed: \(error.localizedDescription)") }
-            }
-        }
+        sync.syncInvoices([invoice])
     }
 
     func updateInvoice(
@@ -308,13 +297,7 @@ final class InvoiceViewModel {
         modelContext.delete(invoice)
         _ = saveContext()
         fetchInvoices()
-
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.deleteInvoice(with: invoiceID) }
-                catch { PersistenceController.logger.error("CloudKit invoice delete failed: \(error.localizedDescription)") }
-            }
-        }
+        sync.deleteInvoice(with: invoiceID)
     }
 
     /// Add item to invoice
@@ -371,13 +354,7 @@ final class InvoiceViewModel {
         invoice.updateTimestamp()
         _ = saveContext()
         fetchInvoices()
-
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.syncInvoices([invoice]) }
-                catch { PersistenceController.logger.error("CloudKit invoice sync failed: \(error.localizedDescription)") }
-            }
-        }
+        sync.syncInvoices([invoice])
     }
 
     func markSent(_ invoice: Invoice) {

--- a/InvoiceGeneration/ViewModels/IssuerViewModel.swift
+++ b/InvoiceGeneration/ViewModels/IssuerViewModel.swift
@@ -6,13 +6,15 @@ import SwiftData
 @Observable
 final class IssuerViewModel {
     private let modelContext: ModelContext
+    private let sync: SyncCoordinator
 
     var issuers: [Issuer] = []
     var isLoading = false
     var errorMessage: String?
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, syncCoordinator: SyncCoordinator = .shared) {
         self.modelContext = modelContext
+        self.sync = syncCoordinator
         fetchIssuers()
     }
 
@@ -73,14 +75,7 @@ final class IssuerViewModel {
 
         guard saveContext() else { return nil }
         fetchIssuers()
-
-        if SubscriptionService.shared.syncEnabled {
-            Task {
-                do { try await CloudKitService.shared.syncIssuers([issuer]) }
-                catch { PersistenceController.logger.error("CloudKit issuer sync failed: \(error.localizedDescription)") }
-            }
-        }
-
+        sync.syncIssuers([issuer])
         return issuer
     }
 
@@ -125,12 +120,7 @@ final class IssuerViewModel {
         let success = saveContext()
         if success {
             fetchIssuers()
-            if SubscriptionService.shared.syncEnabled {
-                Task {
-                    do { try await CloudKitService.shared.syncIssuers([issuer]) }
-                    catch { PersistenceController.logger.error("CloudKit issuer sync failed: \(error.localizedDescription)") }
-                }
-            }
+            sync.syncIssuers([issuer])
         }
 
         return success
@@ -144,12 +134,7 @@ final class IssuerViewModel {
         let success = saveContext()
         if success {
             fetchIssuers()
-            if SubscriptionService.shared.syncEnabled {
-                Task {
-                    do { try await CloudKitService.shared.syncIssuers([issuer]) }
-                    catch { PersistenceController.logger.error("CloudKit issuer sync failed: \(error.localizedDescription)") }
-                }
-            }
+            sync.syncIssuers([issuer])
         }
         return success
     }


### PR DESCRIPTION
## Summary

- **Issue #8 — De-dupe sync triggers:** The `if syncEnabled { Task { … } }` idiom was copy-pasted verbatim across `InvoiceViewModel` (4×), `ClientViewModel` (3×) and `IssuerViewModel` (3×) — 10 independent copies of identical boilerplate. A new `SyncCoordinator` service (`Services/SyncCoordinator.swift`) encapsulates the pattern once per operation type.
- **Issue #9 — Injectable dependency:** All three ViewModels now accept `syncCoordinator: SyncCoordinator = .shared` at init time. Existing call sites that construct ViewModels with only a `ModelContext` are unchanged (default argument kicks in). Tests can inject a no-op stub without touching any global singleton.

## What changed

| File | Change |
|---|---|
| `Services/SyncCoordinator.swift` | **New** — wraps `SubscriptionService` + `CloudKitService` gating/error-logging for all 6 operations (sync + delete for invoices, clients, issuers) |
| `ViewModels/InvoiceViewModel.swift` | Replaced 4 inline sync blocks with `sync.syncInvoices/deleteInvoice` |
| `ViewModels/ClientViewModel.swift` | Replaced 3 inline sync blocks with `sync.syncClients/deleteClient` |
| `ViewModels/IssuerViewModel.swift` | Replaced 3 inline sync blocks with `sync.syncIssuers` |

Runtime behaviour is identical — the coordinator's `.shared` instance delegates to `SubscriptionService.shared` and `CloudKitService.shared` exactly as before.

## Test plan

- [ ] Build succeeds (`xcodebuild … build` → `BUILD SUCCEEDED`) ✅ (-71 lines removed)
- [ ] Create/update/delete invoice — CloudKit sync still fires when Pro is active
- [ ] Create/update/delete client — CloudKit sync still fires when Pro is active
- [ ] Create/update/delete issuer — CloudKit sync still fires when Pro is active
- [ ] When sync is disabled (free tier), no CloudKit calls are made

🤖 Generated with [Claude Code](https://claude.com/claude-code)